### PR TITLE
Alternative color, and how we calculate spaces between strings

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -4,7 +4,7 @@ import 'package:image/image.dart';
 
 Future<void> main() async {
   final profile = await CapabilityProfile.load();
-  final generator = Generator(PaperSize(), profile);
+  final generator = Generator(PaperSize(), profile, 'gs');
   List<int> bytes = [];
 
   bytes += generator.text(

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -35,6 +35,8 @@ const cTurn90Off = '${esc}V\x00'; // Turn 90° clockwise rotation mode off
 const cCodeTable = '${esc}t'; // Select character code table [N]
 const cKanjiOn = '$fs&'; // Select Kanji character mode
 const cKanjiOff = '$fs.'; // Cancel Kanji character mode
+const cAltColorOn = '${esc}r\x01'; // Use alternative color (e.g., red)
+const cAltColorOff = '${esc}r\x00'; // Use default color (e.g., black)
 
 // Print Position
 const cAlignLeft = '${esc}a0'; // Left justification

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -18,6 +18,7 @@ class Generator {
       PosStyles(fontType: PosFontType.fontA, align: PosAlign.center);
   // Ticket config
   final PaperSize _paperSize;
+  final String GSorESC;
   CapabilityProfile _profile;
 
   // Global styles
@@ -29,7 +30,8 @@ class Generator {
 
   Generator(
     this._paperSize,
-    this._profile, {
+    this._profile,
+    this.GSorESC, {
     this.spaceBetweenRows = 5,
     this.chineseEnabled = false,
     this.globalStyles = const PosStyles(fontType: PosFontType.fontA),
@@ -66,26 +68,58 @@ class Generator {
     }
   }
 
-  Uint8List _encode(String text) {
-    // replace some non-ascii characters
-    text = text
-        .replaceAll("’", "'")
-        .replaceAll("´", "'")
-        .replaceAll("»", '"')
-        .replaceAll("•", '.');
+  Uint8List _encode(String text,
+      {PosStyles? styles, bool alternativeColor = false}) {
     List<int> textBytes = [];
-    // for (var i = 0; i < text.length; ++i) {
-    //   if (_isChinese(text[i])) {
-    //     textBytes += cKanjiOn.codeUnits;
-    //     textBytes += gbk_bytes.encode(text[i]);
-    //   } else {
-    //     textBytes += cKanjiOff.codeUnits;
-    //     textBytes += latin1.encode(text[i]);
-    //   }
+
+    // Initialize the printer (ESC @)
+    // textBytes.addAll([0x1B, 0x40]);
+
+    // // Set alternative color (ESC r 1 for red, ESC r 0 for black)
+    // if (alternativeColor) {
+    //   textBytes.addAll([0x1B, 0x72, 0x01]);
+    // } else {
+    //   textBytes.addAll([0x1B, 0x72, 0x00]);
     // }
-    textBytes += cKanjiOff.codeUnits;
+
+    // // Apply styles if provided
+    // if (styles != null) {
+    //   int fontSize = 0;
+    //   fontSize |= 0x12;
+    //   textBytes
+    //       .addAll([0x1B, 0x21, fontSize]); // GS ! n command to set text size
+    // }
+
+    // Convert text to bytes using Latin-1 encoding
     textBytes += latin1.encode(text);
+
+    // // Reset styles if they were set
+    // if (styles != null) {
+    //   textBytes.addAll([0x1D, 0x21, 0x00]); // Reset to normal size
+    // }
+
+    // Ensure color is reset to black after printing
+    // textBytes.addAll([0x1B, 0x72, 0x00]);
+
     return Uint8List.fromList(textBytes);
+    // text = text
+    //     .replaceAll("’", "'")
+    //     .replaceAll("´", "'")
+    //     .replaceAll("»", '"')
+    //     .replaceAll("•", '.');
+    // List<int> textBytes = [];
+    // // for (var i = 0; i < text.length; ++i) {
+    // //   if (_isChinese(text[i])) {
+    // //     textBytes += cKanjiOn.codeUnits;
+    // //     textBytes += gbk_bytes.encode(text[i]);
+    // //   } else {
+    // //     textBytes += cKanjiOff.codeUnits;
+    // //     textBytes += latin1.encode(text[i]);
+    // //   }
+    // // }
+    // textBytes += cKanjiOff.codeUnits;
+    // textBytes += latin1.encode(text);
+    // return Uint8List.fromList(textBytes);
   }
 
   /// Break text into chinese/non-chinese lexemes
@@ -248,6 +282,15 @@ class Generator {
 
   List<int> _setStyles(PosStyles styles) {
     List<int> bytes = [];
+
+    // Disable color
+    bytes += cAltColorOff.codeUnits;
+
+    // Characters color
+    if (styles.alternativeColor) {
+      bytes += cAltColorOn.codeUnits;
+    }
+
     PosAlign? align;
     if (styles.align != globalStyles.align) {
       align = styles.align;
@@ -275,10 +318,17 @@ class Generator {
         fontType == PosFontType.fontA ? cFontA.codeUnits : cFontB.codeUnits;
 
     // Characters size
-    bytes += Uint8List.fromList(
-      List.from(cSizeGSn.codeUnits)
-        ..add(PosTextSize.decSize(styles.height, styles.width)),
-    );
+    if (GSorESC == 'gs') {
+      bytes += Uint8List.fromList(
+        List.from(cSizeGSn.codeUnits)
+          ..add(PosTextSize.decSize(styles.height, styles.width)),
+      );
+    } else {
+      bytes += Uint8List.fromList(
+        List.from(cSizeESCn.codeUnits)
+          ..add(PosTextSize.decSize(styles.height, styles.width)),
+      );
+    }
 
     // Set local code table
     if (styles.codeTable != null) {
@@ -297,6 +347,7 @@ class Generator {
           ..add(_profile.getCodePageId(globalStyles.codeTable)),
       );
     }
+
     return bytes;
   }
 
@@ -310,14 +361,11 @@ class Generator {
     return bytes;
   }
 
-  List<int> text(
-    String text, {
-    PosStyles? styles,
-    int linesAfter = 0,
-  }) {
+  List<int> text(String text,
+      {PosStyles? styles, int linesAfter = 0, bool alternativeColor = false}) {
     List<int> bytes = [];
     bytes += _text(
-      _encode(text),
+      _encode(text, styles: styles, alternativeColor: alternativeColor),
       styles: styles,
     );
     // Ensure at least one line break after the text
@@ -420,58 +468,43 @@ class Generator {
   ///
   /// A row contains up to 12 columns. A column has a width between 1 and 12.
   /// Total width of columns in one row must be equal 12.
-  List<int> row(List<PosColumn> cols) {
-    List<int> bytes = [];
-    Map<String, List<PosColumn>> rows = {'current': cols, 'next': []};
+  List<int> row(List<PosColumn> cols,
+      {PosStyles? styles, bool alternativeColor = false}) {
+    List<String> strings = cols.map((c) => c.text).toList();
 
-    final isSumValid = cols.fold(0, (int sum, col) => sum + col.width) == 12;
+    int maxStringLenght = _paperSize.fontACharsPerLine;
 
-    if (!isSumValid) {
-      throw Exception('Total columns width must be equal to 12');
-    }
+    // if (styles != null) {
+    //   maxStringLenght = (_paperSize.fontACharsPerLine ~/ 1.2);
+    // }
 
-    void _processRow() {
-      for (int i = 0; i < rows['current']!.length; ++i) {
-        PosColumn col = rows['current']![i];
+    // Calculate the total length of all strings combined
+    int totalStringLength =
+        strings.fold(0, (length, string) => length + string.length);
 
-        int colInd = rows['current']!
-            .sublist(0, i)
-            .fold(0, (int sum, col) => sum + col.width);
-        double charWidth = _getCharWidth(col.styles);
-        double fromPos = _colIndToPosition(colInd);
-        final double toPos =
-            _colIndToPosition(colInd + col.width) - spaceBetweenRows;
-        int maxCharacters = ((toPos - fromPos) / charWidth).floor();
+    // Calculate the number of spaces needed
+    int totalSpaces = maxStringLenght - totalStringLength;
 
-        int realCharacters = col.text.length;
-        if (realCharacters > maxCharacters) {
-          rows['next']!.add(PosColumn(
-            text: col.text.substring(maxCharacters),
-            width: col.width,
-            styles: col.styles,
-          ));
-          col.text = col.text.substring(0, maxCharacters);
-        } else {
-          rows['next']!
-              .add(PosColumn(text: '', width: col.width, styles: col.styles));
-        }
-        bytes += _text(
-          _encode(col.text),
-          styles: col.styles,
-          colInd: colInd,
-          colWidth: col.width,
-        );
+    // Calculate the number of gaps between the strings
+    int gaps = strings.length - 1;
+
+    // If there are no gaps, return the joined string as is
+    if (gaps == 0) return text(strings.join());
+
+    // Calculate spaces to distribute between each gap
+    int spacesBetween = totalSpaces ~/ gaps;
+    int extraSpaces = totalSpaces % gaps;
+
+    // Build the resulting string
+    String result = '';
+    for (int i = 0; i < strings.length; i++) {
+      result += strings[i];
+      if (i < gaps) {
+        // Add spaces between the words
+        result += ' ' * (spacesBetween + (i < extraSpaces ? 1 : 0));
       }
     }
-
-    while (rows['current']!.any((col) => col.text.isNotEmpty)) {
-      _processRow();
-      bytes += emptyLines(1);
-      rows['current'] = rows['next']!;
-      rows['next'] = [];
-    }
-
-    return bytes;
+    return text(result, styles: styles, alternativeColor: alternativeColor);
   }
 
   /// Print an image using (ESC *) command

--- a/lib/src/pos_styles.dart
+++ b/lib/src/pos_styles.dart
@@ -19,6 +19,7 @@ class PosStyles {
   final PosTextSize width;
   final PosFontType? fontType;
   final String? codeTable;
+  final bool alternativeColor;
 
   const PosStyles({
     this.bold = false,
@@ -28,6 +29,7 @@ class PosStyles {
     this.align = PosAlign.left,
     this.height = PosTextSize.size1,
     this.width = PosTextSize.size1,
+    this.alternativeColor = false,
     this.fontType,
     this.codeTable,
   });
@@ -42,30 +44,31 @@ class PosStyles {
     this.height = PosTextSize.size1,
     this.width = PosTextSize.size1,
     this.fontType = PosFontType.fontA,
+    this.alternativeColor = false,
     this.codeTable = "CP437",
   });
 
-  PosStyles copyWith({
-    bool? bold,
-    bool? reverse,
-    bool? underline,
-    bool? turn90,
-    PosAlign? align,
-    PosTextSize? height,
-    PosTextSize? width,
-    PosFontType? fontType,
-    String? codeTable,
-  }) {
+  PosStyles copyWith(
+      {bool? bold,
+      bool? reverse,
+      bool? underline,
+      bool? turn90,
+      PosAlign? align,
+      PosTextSize? height,
+      PosTextSize? width,
+      PosFontType? fontType,
+      String? codeTable,
+      bool? alternativeColor}) {
     return PosStyles(
-      bold: bold ?? this.bold,
-      reverse: reverse ?? this.reverse,
-      underline: underline ?? this.underline,
-      turn90: turn90 ?? this.turn90,
-      align: align ?? this.align,
-      height: height ?? this.height,
-      width: width ?? this.width,
-      fontType: fontType ?? this.fontType,
-      codeTable: codeTable ?? this.codeTable,
-    );
+        bold: bold ?? this.bold,
+        reverse: reverse ?? this.reverse,
+        underline: underline ?? this.underline,
+        turn90: turn90 ?? this.turn90,
+        align: align ?? this.align,
+        height: height ?? this.height,
+        width: width ?? this.width,
+        fontType: fontType ?? this.fontType,
+        codeTable: codeTable ?? this.codeTable,
+        alternativeColor: alternativeColor ?? this.alternativeColor);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -115,46 +115,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   petitparser:
     dependency: transitive
     description:
@@ -172,26 +164,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -212,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -232,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   xml:
     dependency: transitive
     description:
@@ -241,4 +241,4 @@ packages:
     source: hosted
     version: "5.3.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"


### PR DESCRIPTION
how the functions row() have been changed, we ignore all the properties of 'PosColumn' but text, we don't need to refactor anything.

Now, the row doesn't need width, per PosColumn added, we have a default size position as a "space-between"

We have a style per row instead of each text

Before:

```
 bytes += generator.row([
      PosColumn(
          text: 'Order#' + order.orderNo.toString(),
          styles: PosStyles(
              align: PosAlign.center,
              height: PosTextSize.size1,
              width: PosTextSize.size1),
          width: 4),
      PosColumn(
          text: timeFormat(DateTime.parse(order.created).toLocalTimeZone()),
          styles: PosStyles(
              align: PosAlign.center,
              height: PosTextSize.size1,
              width: PosTextSize.size1),
          width: 4),
      PosColumn(
          text: SharedUtils()
              .dateFormat(DateTime.parse(order.created).toLocalTimeZone()),
          styles: PosStyles(
              align: PosAlign.right,
              height: PosTextSize.size1,
              width: PosTextSize.size1),
          width: 4),
    ]);
```

Now:

```
 bytes += generator.row([
      PosColumn(
          text: 'Order#' + order.orderNo.toString()),
      PosColumn(
          text: timeFormat(DateTime.parse(order.created).toLocalTimeZone()),)
      PosColumn(
          text: SharedUtils()
              .dateFormat(DateTime.parse(order.created).toLocalTimeZone()),),
    ],
    styles: PosStyles(
                  align: PosAlign.right,
                  height: PosTextSize.size1,
                  width: PosTextSize.size1)
    );
```